### PR TITLE
Remove trailing slashes from server url

### DIFF
--- a/openapi.yaml
+++ b/openapi.yaml
@@ -5,7 +5,7 @@ info:
   title: "Robert Koch Institut: Corona Risikogebiete API"
 
 servers:
-  - url: 'https://api.einreiseanmeldung.de/reisendenportal/'
+  - url: 'https://api.einreiseanmeldung.de/reisendenportal'
 
 paths:
   /risikogebiete:


### PR DESCRIPTION
According to the OpenAPI specifications, the server addresses must not end on a slash (see https://swagger.io/specification/#server-object). Importing this in tools like Postman generates defective URLs containing two slashes. This PR fixes this.